### PR TITLE
csexec-divine: start divine in sane environment

### DIFF
--- a/csexec-divine.sh
+++ b/csexec-divine.sh
@@ -84,4 +84,4 @@ DIVINE_ARGS+=("-o" "stdout:notrace")
   /usr/bin/divine2csgrep > "$LOGDIR/pid-$$.out.conv"
 
 # Continue
-exec $(/usr/bin/csexec --print-ld-exec-cmd) "${ARGV[@]}"
+exec $(/usr/bin/csexec --print-ld-exec-cmd ${CSEXEC_ARGV0}) "${ARGV[@]}"

--- a/csexec-divine.sh
+++ b/csexec-divine.sh
@@ -78,9 +78,10 @@ DIVINE_ARGS+=("--report-filename" "$LOGDIR/pid-$$.report")
 DIVINE_ARGS+=("-o" "stdout:notrace")
 
 # Run and convert!
-divine "${DIVINE_ARGS[@]}" "${ARGV[@]}" 2> "$LOGDIR/pid-$$.err" | \
+/usr/bin/env -i /usr/bin/bash -lc 'exec "$@"' divine \
+  /usr/bin/divine "${DIVINE_ARGS[@]}" "${ARGV[@]}" 2> "$LOGDIR/pid-$$.err" | \
   /usr/bin/tee "$LOGDIR/pid-$$.out" | \
-  divine2csgrep > "$LOGDIR/pid-$$.out.conv"
+  /usr/bin/divine2csgrep > "$LOGDIR/pid-$$.out.conv"
 
 # Continue
-exec $(csexec --print-ld-exec-cmd) "${ARGV[@]}"
+exec $(/usr/bin/csexec --print-ld-exec-cmd) "${ARGV[@]}"


### PR DESCRIPTION
csexec-divine is transparently invoked from test programs that often
run in specially crafted environment to exercise the tested binaries.
For example, GNU coreutils sets $PATH such that the just built binaries
are preferred over system-provided binaries with the same name.  This
causes havoc in case divine wants to use system-provided binaries
without specifying them with absolute path.  Especially, when divine
by mistake invokes binaries that use csexec-loader as ELF interpreter,
this recursively invokes csexec-divine and divine in a loop and attacks
the machine with a fork bomb.